### PR TITLE
Converting types in tests as they are incorrect

### DIFF
--- a/basic/check_success/boolop.cvc
+++ b/basic/check_success/boolop.cvc
@@ -11,8 +11,8 @@ void f()
   float g = 3.14 * 2.0;
   bool h = true * false;
 
-  int i = 4/3;
-  int j = 6/0;
+  float i = 4/3;
+  float j = 6/0;
   float k = 5.0/2.0;
   float l = 9.0/0.00;
 

--- a/basic/check_success/parse_operators.cvc
+++ b/basic/check_success/parse_operators.cvc
@@ -1,10 +1,11 @@
 void foo() {
     int a;
     bool b;
+    float c;
     a = 1 + 2;
     a = a - 1;
     a = a * 45;
-    a = a / 9;
+    c = a / 9;
     a = a % 4;
     b = a < 1;
     b = a > 2;


### PR DESCRIPTION
Some of the check_error checks demand that there is strict typechecking (i.e. int a = 5.0 is wrong)
But in the correct tests there are also some cases of this which then are to be thought of as correct (see changed lines)
For the consistency I changed the types to match the expected type (in this case float) so the typechecking goes correctly here.