### PR TITLE
Add test for invalid shadowing

### DIFF
--- a/basic/check_error/shadow_variable_function.cvc
+++ b/basic/check_error/shadow_variable_function.cvc
@@ -2,9 +2,8 @@ int foo()
 {
   return 0;
 }
-int foo = 0;
-int bar = 0;
-int bar()
+
+void bar()
 {
-  return 0;
+  int foo = 0;
 }

--- a/basic/check_error/shadow_variable_function.cvc
+++ b/basic/check_error/shadow_variable_function.cvc
@@ -1,0 +1,10 @@
+int foo()
+{
+  return 0;
+}
+int foo = 0;
+int bar = 0;
+int bar()
+{
+  return 0;
+}


### PR DESCRIPTION
In the current version of the assignment it states "In other words, a function definition never shadows a variable declaration and vice versa". This adds a test for that.